### PR TITLE
Fix Bitbucket text

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,7 +369,7 @@
           <h2>Work</h2>
           <ul>
             <li class="bitbucket">
-              <a href="https://mail.google.com" target="_blank" rel="noopener noreferrer">🪣 BitBucket</a>
+              <a href="https://mail.google.com" target="_blank" rel="noopener noreferrer">🪣 Bitbucket</a>
             </li>
             <li class="jira">
               <a href="https://chat.openai.com" target="_blank" rel="noopener noreferrer">✅ Jira</a>


### PR DESCRIPTION
## Summary
- fix capitalization of Bitbucket link in work bookmarks

## Testing
- `grep -n Bitbucket index.html`

------
https://chatgpt.com/codex/tasks/task_b_68476f40d41c83238bd76ee7a9dfecdb